### PR TITLE
remove hard postgres dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ npm-debug.log
 tmp/**
 ui/**/imported/**
 mocks/
+
+*.db
+*.sqlite

--- a/app/models/visualization.js
+++ b/app/models/visualization.js
@@ -23,13 +23,45 @@ module.exports = function(sequelize, DataTypes) {
         };
     } else {
         schema = {
-            data: 'JSON',
-            opts: 'JSON',
-            settings: 'JSON',
+            data: {
+                type: DataTypes.TEXT,
+                get: function() {
+                    return JSON.parse(this.getDataValue('data') || '{}');
+                },
+                set: function(val) {
+                    return this.setDataValue('data', JSON.stringify(val));
+                }
+            },
+            opts: {
+                type: DataTypes.TEXT,
+                get: function() {
+                    return JSON.parse(this.getDataValue('opts') || '{}');
+                },
+                set: function(val) {
+                    return this.setDataValue('opts', JSON.stringify(val));
+                }
+            },
+            settings: {
+                type: DataTypes.TEXT,
+                get: function() {
+                    return JSON.parse(this.getDataValue('settings') || '{}');
+                },
+                set: function(val) {
+                    return this.setDataValue('settings', JSON.stringify(val));
+                }
+            },
             name: DataTypes.STRING,
             description: DataTypes.TEXT,
             type: DataTypes.STRING,
-            images: DataTypes.STRING
+            images: {
+                type: DataTypes.TEXT,
+                get: function() {
+                    return JSON.parse(this.getDataValue('images') || '[]');
+                },
+                set: function(val) {
+                    return this.setDataValue('images', JSON.stringify(val));
+                }
+            }
         };
     }
 
@@ -178,12 +210,11 @@ module.exports = function(sequelize, DataTypes) {
         hooks: {
             beforeValidate: function(visualization, next) {
 
-                if(!isPostgres) {
-                    visualization.images = JSON.stringify(visualization.images);
+                if(isPostgres) {
+                    visualization.settings = JSON.stringify(visualization.settings);
+                    visualization.data = JSON.stringify(visualization.data);
+                    visualization.opts = JSON.stringify(visualization.opts);
                 }
-                visualization.settings = JSON.stringify(visualization.settings);
-                visualization.data = JSON.stringify(visualization.data);
-                visualization.opts = JSON.stringify(visualization.opts);
                 next();
             }
         }

--- a/app/models/visualization.js
+++ b/app/models/visualization.js
@@ -177,6 +177,10 @@ module.exports = function(sequelize, DataTypes) {
 
         hooks: {
             beforeValidate: function(visualization, next) {
+
+                if(!isPostgres) {
+                    visualization.images = JSON.stringify(visualization.images);
+                }
                 visualization.settings = JSON.stringify(visualization.settings);
                 visualization.data = JSON.stringify(visualization.data);
                 visualization.opts = JSON.stringify(visualization.opts);

--- a/app/models/visualizationtype.js
+++ b/app/models/visualizationtype.js
@@ -27,7 +27,7 @@ module.exports = function(sequelize, DataTypes) {
 
             sampleData: 'JSON',
             sampleOptions: 'JSON',
-            sampleImages: DataTypes.STRING,
+            sampleImages: DataTypes.ARRAY(DataTypes.STRING),
 
             javascript: DataTypes.TEXT,
             markup: DataTypes.TEXT,

--- a/app/models/visualizationtype.js
+++ b/app/models/visualizationtype.js
@@ -43,10 +43,33 @@ module.exports = function(sequelize, DataTypes) {
 
         thumbnailLocation: DataTypes.STRING,
 
-        sampleData: 'JSON',
-        sampleOptions: 'JSON',
-        sampleImages: DataTypes.STRING,
-
+        sampleData: {
+            type: DataTypes.TEXT,
+            get: function() {
+                return JSON.parse(this.getDataValue('sampleData') || '{}');
+            },
+            set: function(val) {
+                return this.setDataValue('sampleData', JSON.stringify(val));
+            }
+        },
+        sampleOptions: {
+            type: DataTypes.TEXT,
+            get: function() {
+                return JSON.parse(this.getDataValue('sampleOptions') || '{}');
+            },
+            set: function(val) {
+                return this.setDataValue('sampleOptions', JSON.stringify(val));
+            }
+        },
+        sampleImages: {
+            type: DataTypes.TEXT,
+            get: function() {
+                return JSON.parse(this.getDataValue('sampleImages') || '[]');
+            },
+            set: function(val) {
+                return this.setDataValue('sampleImages', JSON.stringify(val));
+            }
+        },
         javascript: DataTypes.TEXT,
         markup: DataTypes.TEXT,
         styles: DataTypes.TEXT
@@ -227,11 +250,10 @@ module.exports = function(sequelize, DataTypes) {
 
             beforeValidate: function(vizType, next) {
 
-                if(!isPostgres) {
-                    vizType.sampleImages = JSON.stringify(vizType.sampleImages);
+                if(isPostgres) {
+                    vizType.sampleData = JSON.stringify(vizType.sampleData);
+                    vizType.sampleOptions = JSON.stringify(vizType.sampleOptions);
                 }
-                vizType.sampleData = JSON.stringify(vizType.sampleData);
-                vizType.sampleOptions = JSON.stringify(vizType.sampleOptions);
                 next();
             }
         }

--- a/config/database.js
+++ b/config/database.js
@@ -18,6 +18,28 @@ module.exports = {
     "sync": {"force": true},
     "storage": 'database.sqlite',
     "logging": false
+  },  
+  "test": {
+    "username": null,
+    "password": null,
+    "database": "lightning-viz",
+    "host": "127.0.0.1",
+    "dialect": "postgres",
+    "port": 5432,
+    "sync": {"force": true},
+    "storage": 'database.sqlite',
+    "logging": false
+  },
+  "test-sqlite": {
+    "username": null,
+    "password": null,
+    "database": "lightning-viz",
+    "host": "127.0.0.1",
+    "dialect": "sqlite",
+    "port": 5432,
+    "sync": {"force": true},
+    "storage": 'database.sqlite',
+    "logging": false
   },
   "production": {
     database: (dbUrl) ? dbUrl.path.replace('/', '') : 'lightning-viz',

--- a/config/database.js
+++ b/config/database.js
@@ -13,9 +13,10 @@ module.exports = {
     "password": null,
     "database": "lightning-viz",
     "host": "127.0.0.1",
-    "dialect": "postgres",
+    "dialect": "sqlite",
     "port": 5432,
     "sync": {"force": true},
+    "storage": 'database.sqlite',
     "logging": false
   },
   "production": {

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "webshot": "^0.15.3",
     "winston": "^0.7.3",
     "yargs": "^1.3.3",
-    "underscore.nest": "git://github.com/mathisonian/underscore.nest"
+    "underscore.nest": "git://github.com/mathisonian/underscore.nest",
+    "sqlite3": "~3.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "should": "*",
     "simplify-js": "^1.2.1",
     "socket.io": "~1.0.6",
+    "sqlite3": "~3.0.4",
     "superagent": "^0.18.2",
     "supertest": "*",
     "svg-path-generator": "^1.0.0",
@@ -118,12 +119,11 @@
     "three.js": "git://github.com/mathisonian/three.js",
     "tiny-lr": "0.0.5",
     "topojson": "^1.6.18",
+    "underscore.nest": "git://github.com/mathisonian/underscore.nest",
     "validator": "~3.17.0",
     "view-helpers": "^0.1.5",
     "webshot": "^0.15.3",
     "winston": "^0.7.3",
-    "yargs": "^1.3.3",
-    "underscore.nest": "git://github.com/mathisonian/underscore.nest",
-    "sqlite3": "~3.0.4"
+    "yargs": "^1.3.3"
   }
 }

--- a/tasks/get_default_visualizations.js
+++ b/tasks/get_default_visualizations.js
@@ -8,10 +8,10 @@ module.exports = function(cb) {
         .spread(function() {
             var vizTypes = Array.prototype.slice.call(arguments, 0);
             console.log('Created Viz Types: ' + _.pluck(vizTypes, 'name').join(', '));
-            cb();
+            cb && cb();
         }).fail(function(err) {
             console.log(err);
-            cb(err);
+            cb && cb(err);
         });
 
 };

--- a/test/test.js
+++ b/test/test.js
@@ -69,15 +69,15 @@ describe('multi repo import tests', function() {
 
 describe('visualization model', function() {
 
-    it('should query json data', function(done) {
+    var data = {
+        key1: ['an', 'array', 'of', 'strings'],
+        key2: {
+            an: 'object'
+        },
+        key3: 'a string'
+    };
 
-        var data = {
-            key1: ['an', 'array', 'of', 'strings'],
-            key2: {
-                an: 'object'
-            },
-            key3: 'a string'
-        };
+    it('should query json data', function(done) {
 
         models.Visualization.create({
             data: data,
@@ -92,6 +92,70 @@ describe('visualization model', function() {
                     expect(results.length).to.be(1);
                     expect(results[0]).to.have.property('data');
                     expect(results[0].data).to.eql(data.key1);
+                    done();
+                });
+
+        });
+    });
+
+    it('should get query a named object', function(done) {
+        
+        models.Visualization.create({
+            data: data,
+            type: 'line'
+        }).then(function(viz) {
+            var vid = viz.id;
+
+            models.Visualization
+                .getNamedObjectForVisualization(vid, 'key2')
+                .then(function(results) {
+                    expect(results).to.be.an('array');
+                    expect(results.length).to.be(1);
+                    expect(results[0]).to.have.property('key2');
+                    expect(results[0].key2).to.eql(data.key2);
+                    done();
+                });
+
+        });
+    });
+
+    it('should get query a named with index', function(done) {
+        
+        models.Visualization.create({
+            data: data,
+            type: 'line'
+        }).then(function(viz) {
+            var vid = viz.id;
+
+            models.Visualization
+                .getNamedObjectAtIndexForVisualization(vid, 'key1', 2)
+                .then(function(results) {
+                    expect(results).to.be.an('array');
+                    expect(results.length).to.be(1);
+                    expect(results[0]).to.have.property('key1');
+                    expect(results[0].key1).to.eql(data.key1[2]);
+                    done();
+                });
+
+        });
+    });
+
+    it('should get query settings', function(done) {
+        
+        models.Visualization.create({
+            settings: data,
+            type: 'line'
+        }).then(function(viz) {
+            var vid = viz.id;
+
+
+            models.Visualization
+                .querySettingsForVisualization(vid, ['key1'])
+                .then(function(results) {
+                    expect(results).to.be.an('array');
+                    expect(results.length).to.be(1);
+                    expect(results[0]).to.have.property('settings');
+                    expect(results[0].settings).to.eql(data.key1);
                     done();
                 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,13 +11,15 @@ var _ = require('lodash');
 describe('repo import tests', function() {
 
     before(function(done) {
-
-        models.VisualizationType
-            .destroy({
-                name: 'imported-matrix'
-            }).success(function() {
-                done();
-            });
+        models.sequelize.sync({force: false})
+        .success(function() {
+            models.VisualizationType
+                .destroy({
+                    name: 'imported-matrix'
+                }).success(function() {
+                    done();
+                });
+        });
     });
 
 
@@ -33,23 +35,6 @@ describe('repo import tests', function() {
                 expect(err).to.not.be.ok();
             });
     });
-
-    // it('should create files in the UI folder from a remote repository', function(done) {
-    //     models.VisualizationType
-    //         .find({
-    //             where: {
-    //                 name: 'imported-matrix'
-    //             }
-    //         }).success(function(vizType) {
-    //             return vizType.exportToFS();
-    //         }).spread(function() {
-    //             done();
-    //         }).error(function(err) {
-    //             console.log(err);
-    //             expect(err).to.not.be.ok();
-    //         });
-    // });
-
 });
 
 
@@ -66,7 +51,7 @@ describe('multi repo import tests', function() {
 
     it('should fetch default visualizations from a remote repository', function(done) {
         models.VisualizationType
-            .createManyFromRepoURL('https://github.com/mathisonian/lightning-default-visualizations')
+            .createManyFromRepoURL('https://github.com/lightning-viz/lightning-default-visualizations')
             .spread(function() {
                 var vizTypes = Array.prototype.slice.call(arguments, 0);
                 expect(vizTypes).to.be.an('array');
@@ -77,21 +62,40 @@ describe('multi repo import tests', function() {
             });
     });
 
-    // it('should create files in the UI folder from the remote repository', function(done) {
-    //     models.VisualizationType
-    //         .findAll().success(function(vizTypes) {
-
-    //             _.each(vizTypes, function(vizType) {
-    //                 vizType.exportToFS();
-    //             });
-
-    //         }).spread(function() {
-    //             done();
-    //         }).error(function(err) {
-    //             console.log(err);
-    //             expect(err).to.not.be.ok();
-    //         });
-    // });
 
 });
 
+
+
+describe('visualization model', function() {
+
+    it('should query json data', function(done) {
+
+        var data = {
+            key1: ['an', 'array', 'of', 'strings'],
+            key2: {
+                an: 'object'
+            },
+            key3: 'a string'
+        };
+
+        models.Visualization.create({
+            data: data,
+            type: 'line'
+        }).then(function(viz) {
+            var vid = viz.id;
+
+            models.Visualization
+                .queryDataForVisualization(vid, ['key1'])
+                .then(function(results) {
+                    expect(results).to.be.an('array');
+                    expect(results.length).to.be(1);
+                    expect(results[0]).to.have.property('data');
+                    expect(results[0].data).to.eql(data.key1);
+                    done();
+                });
+
+        });
+    });
+
+})


### PR DESCRIPTION
This pull request removes the hard dependency on Postgres. At this time, this branch supports any database that is supported as a dialect of the ORM Sequelize, including:
* Postgres
* SQLite
* MySQL
* MariaDB

If users chose not to use Postgres,  JSON parsing will be done in memory, and may be inefficient for large datasets.

I've also added separating testing ENV flags for testing with postgres and sqlite. These can be used like:
```
$ NODE_ENV=test npm test # tests run on Postgres
$ NODE_ENV=test-sqlite npm test  # tests run on SQLite
```

