### PR TITLE
Check for kernel

### DIFF
--- a/ui/js/pages/ipython-comm.js
+++ b/ui/js/pages/ipython-comm.js
@@ -10,7 +10,7 @@ var readCommData = function(commData, field) {
 };
 
 
-if(IPython) {
+if(IPython.notebook.kernel) {
     IPython.notebook.kernel.comm_manager.register_target('lightning', function(comm, data) {
         var id = readCommData(data, 'id');
         lightningCommMap[id] = comm;


### PR DESCRIPTION
I was able to reliably reproduce a notebook glitch related to the new comm functionality. In a notebook where the context was initialized as `lgn = Lightning(ipython=True)`, after refreshing the page, this error would appear in the cell where the context was initialized:

```
Javascript error adding output!
TypeError: Cannot read property 'comm_manager' of null
See your browser Javascript console for more details.
```

I confirmed that on the server `IPython.notebook` was defined, but not the kernel. This fix prevents the error, but I'm not sure whether there's still an underlying issue, see what you think.